### PR TITLE
Bugfix infinite loop at 3 eaten

### DIFF
--- a/js/snakeunit.js
+++ b/js/snakeunit.js
@@ -69,7 +69,7 @@ SnakeUnit.prototype.addUnit = function() {
     var prev_pos    = this.getPosition();
     var prev_vel    = this.getVelocity();
     while(temp._next != null) {
-        temp        = this._next;
+        temp        = temp._next;
         prev_pos    = this.getPosition();
         prev_vel    = this.getVelocity();
     }


### PR DESCRIPTION
Hi ishankhare07.

I know you have this marked as a wontfix, but also as a help wanted, so I thought I'd go ahead and make note of this.  You were exactly correct as to where the bug was.  Inside the while loop, you were setting the value of temp to be this._next.  On every execution of the loop, you handled the first segment and then the second segment, but then looped forever on the second statement.  What you were really looking for, and I imagine intended, was to set temp equal to the next segment from temp.

With this simple change (submitted as a pr for notice, not necessarily because you need to merge it), the endless loop is broken and the snake can keep on getting super long :-).

Cheers,

-branespace
